### PR TITLE
tweak: add ln to rml_libs

### DIFF
--- a/resonite-headless/Dockerfile
+++ b/resonite-headless/Dockerfile
@@ -95,11 +95,12 @@ RUN	${HEADLESSDIR}/scripts/install_resonite.sh
 # ResoniteModLoader
 FROM build AS rml-true
 
-RUN	mkdir -p ${STEAMAPPDIR}/Headless/Libraries ${STEAMAPPDIR}/Headless/rml_libs && \
+RUN	mkdir -p ${STEAMAPPDIR}/Headless/Libraries ${HEADLESSDIR}/rml_libs && \
+	curl -sqLo ${HEADLESSDIR}/rml_libs/0Harmony-Net8.dll ${RMLLIBURL} && \
+	ln -sf ${HEADLESSDIR}/rml_libs ${STEAMAPPDIR}/Headless/rml_libs && \
 	ln -sf ${HEADLESSDIR}/rml_mods ${STEAMAPPDIR}/Headless/rml_mods && \
 	ln -sf ${HEADLESSDIR}/rml_config ${STEAMAPPDIR}/Headless/rml_config && \
-	curl -sqLo ${STEAMAPPDIR}/Headless/Libraries/ResoniteModLoader.dll ${RMLURL} &&\
-	curl -sqLo ${STEAMAPPDIR}/Headless/rml_libs/0Harmony-Net8.dll ${RMLLIBURL}
+	curl -sqLo ${STEAMAPPDIR}/Headless/Libraries/ResoniteModLoader.dll ${RMLURL}
 
 # Do nothing
 FROM build AS rml-false


### PR DESCRIPTION
This adds a symbolic link for `rml_libs` to make it easier to mount a volume for RML libraries during times where we need to specify our own DLLs (i.e. when Harmony or RML's provided Harmony DLL does not have a .NET 9 release yet but we are able to compile our own).